### PR TITLE
fix: Add URI generation method in HandlerAgent class

### DIFF
--- a/src/agent/HandlerAgent.ts
+++ b/src/agent/HandlerAgent.ts
@@ -268,6 +268,13 @@ export class HandlerAgent {
   /**
    *
    */
+  generateURIFromCreateMessage(message: CreateSkeetMessage){
+    return `at://${message.did}/app.bsky.feed.post/${message.rkey}`
+  }
+
+  /**
+   *
+   */
   generateReplyFromMessage(message: CreateSkeetMessage): Reply {
     let reply: Reply; //TODO Test
     const parentReply: Subject = {

--- a/tests/agent/HandlerAgentUtils.test.ts
+++ b/tests/agent/HandlerAgentUtils.test.ts
@@ -1,0 +1,48 @@
+import { CreateSkeetMessage, HandlerAgent } from "../../src";
+import { AtpSessionData, BskyAgent } from "@atproto/api";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+jest.mock("@atproto/api", () => jest.genMockFromModule("@atproto/api"));
+
+describe("HandlerAgent", () => {
+  let handlerAgent: HandlerAgent;
+  const testHandle: string = "testhandle";
+  const testPassword: string = "testpassword";
+  let mockedAgent: BskyAgent;
+  beforeEach(() => {
+      mockedAgent = {
+        session: {
+          did: "did:plc:2bnsooklzchcu5ao7xdjosrs",
+        } as AtpSessionData,
+      } as BskyAgent;
+      handlerAgent = new HandlerAgent(
+        "agentName",
+        testHandle,
+        testPassword,
+        mockedAgent,
+      );
+  });
+
+  it("generateURIFromCreateMessage creates expected uri", () => {
+    const message: CreateSkeetMessage = {
+      cid: "",
+      collection: "",
+      opType: "c",
+      record: {
+        $type: "",
+        createdAt: "",
+        subject: ""
+      },
+      seq: 0,
+      did: 'did:example:12345',
+      rkey: 'feed1'
+      // other necessary fields...
+    };
+    const result = handlerAgent.generateURIFromCreateMessage(message);
+
+    expect(result).toEqual('at://did:example:12345/app.bsky.feed.post/feed1');
+  });
+
+});


### PR DESCRIPTION
A new method, 'generateURIFromCreateMessage', was added to the HandlerAgent class for URI generation from CreateMessage. A corresponding test for this functionality was also written and added to 'HandlerAgentUtils.test.ts'.