### PR TITLE
fix: Update argument type in ReplyToSkeetWithGeneratedTextAction

### DIFF
--- a/src/actions/post/SkeetActions.ts
+++ b/src/actions/post/SkeetActions.ts
@@ -59,7 +59,7 @@ export class ReplyToSkeetAction extends AbstractMessageAction {
 export class ReplyToSkeetWithGeneratedTextAction extends AbstractMessageAction {
   constructor(
     private textGenerator: (
-      arg0: JetstreamMessage,
+      arg0: CreateSkeetMessage,
       arg1: HandlerAgent,
     ) => string,
   ) {


### PR DESCRIPTION
Updated the argument type for the `textGenerator` function in the `ReplyToSkeetWithGeneratedTextAction` class from `JetstreamMessage` to `CreateSkeetMessage` to better reflect the function's usage.