### PR TITLE
Fix follow and unfollow in agent

### DIFF
--- a/src/agent/HandlerAgent.ts
+++ b/src/agent/HandlerAgent.ts
@@ -195,20 +195,20 @@ export class HandlerAgent {
 
     //region Follow Helpers
 
-    /**
-     *
-     * @param follows
-     */
-    extractDIDsFromProfiles(follows: ProfileView[]): string[] {
-        return follows.map((item) => item.did);
-    }
-
-    getRecordForDid(
-        targetDid: string,
-        data: ProfileView[]
-    ): ProfileView | undefined {
-        return data.find((item) => item.did === targetDid);
-    }
+    // /**
+    //  *
+    //  * @param follows
+    //  */
+    // extractDIDsFromProfiles(follows: ProfileView[]): string[] {
+    //     return follows.map((item) => item.did);
+    // }
+    //
+    // getRecordForDid(
+    //     targetDid: string,
+    //     data: ProfileView[]
+    // ): ProfileView | undefined {
+    //     return data.find((item) => item.did === targetDid);
+    // }
 
     //endregion
 

--- a/src/agent/HandlerAgent.ts
+++ b/src/agent/HandlerAgent.ts
@@ -113,7 +113,7 @@ export class HandlerAgent {
             limit: limit,
         };
         const resp = await this.agent?.getFollows(body);
-        return resp?.data;
+        return resp?.data.follows;
     }
 
     /**
@@ -133,7 +133,7 @@ export class HandlerAgent {
             limit: limit,
         };
         const resp = await this.agent?.getFollowers(body);
-        return resp?.data;
+        return resp?.data.followers;
     }
 
     /**

--- a/src/agent/HandlerAgent.ts
+++ b/src/agent/HandlerAgent.ts
@@ -86,72 +86,104 @@ export class HandlerAgent {
     //endregion
 
     //region Follower Interactions
+
     /**
-     *
+     * getProfile
      */
-    async getFollows(userDID: string | undefined = undefined) {
-        if (userDID === undefined) {
-            userDID = this.getDid;
-        }
-        const resp = await this.agent?.getFollows({ actor: userDID });
-        return resp?.data.follows;
+
+    async getProfile(did: string) {
+        const response = await this.agent?.getProfile({ actor: did });
+        return response?.data;
     }
 
     /**
      *
      */
-    async getFollowers(userDID: string | undefined = undefined) {
+    async getFollows(
+        userDID: string | undefined = undefined,
+        cursor: string | undefined = undefined,
+        limit: number = 50
+    ) {
         if (userDID === undefined) {
             userDID = this.getDid;
         }
-        const resp = await this.agent?.getFollowers({ actor: userDID });
-        return resp?.data.followers;
+        const body = {
+            actor: userDID,
+            cursor: cursor,
+            limit: limit,
+        };
+        const resp = await this.agent?.getFollows(body);
+        return resp?.data;
+    }
+
+    /**
+     *
+     */
+    async getFollowers(
+        userDID: string | undefined = undefined,
+        cursor: string | undefined = undefined,
+        limit: number = 50
+    ) {
+        if (userDID === undefined) {
+            userDID = this.getDid;
+        }
+        const body = {
+            actor: userDID,
+            cursor: cursor,
+            limit: limit,
+        };
+        const resp = await this.agent?.getFollowers(body);
+        return resp?.data;
     }
 
     /**
      *
      */
     async isFollowing(userDID: string): Promise<boolean> {
-        const getFollowsResponse = await this.getFollows();
-
-        if (Array.isArray(getFollowsResponse)) {
-            const following = this.extractDIDsFromProfiles(getFollowsResponse);
-            return following.includes(userDID);
+        const followProfile = await this.getProfile(userDID);
+        if (!followProfile) {
+            return false;
         }
-        return false;
-    }
-
-    /**
-     *
-     */
-    async isFollowedBy(userDID: string): Promise<boolean> {
-        const getFollowerResponse = await this.getFollowers();
-        if (Array.isArray(getFollowerResponse)) {
-            const followers = this.extractDIDsFromProfiles(getFollowerResponse);
-            return followers.includes(userDID);
+        const viewer = followProfile?.viewer;
+        if (!viewer?.following) {
+            return false;
         }
-        return false;
-    }
-
-    /**
-     *
-     */
-    async followUser(did: string): Promise<boolean> {
-        await this.agent?.follow(did);
         return true;
     }
 
     /**
      *
      */
-    async unfollowUser(did: string): Promise<boolean> {
-        const getFollowsResponse = await this.getFollows();
-
-        if (!Array.isArray(getFollowsResponse)) {
+    async isFollowedBy(userDID: string): Promise<boolean> {
+        const followProfile = await this.getProfile(userDID);
+        if (!followProfile) {
             return false;
         }
-        const resp = this.getRecordForDid(did, getFollowsResponse);
-        const followLink = resp?.viewer?.following;
+        const viewer = followProfile?.viewer;
+        if (!viewer?.followedBy) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     *
+     */
+    async followUser(userDID: string): Promise<boolean> {
+        await this.agent?.follow(userDID);
+        return true;
+    }
+
+    /**
+     *
+     */
+    async unfollowUser(userDID: string): Promise<boolean> {
+        const followProfile = await this.getProfile(userDID);
+        if (!followProfile) {
+            return false;
+        }
+        const followLink = followProfile?.viewer?.following;
+        console.log(followProfile.viewer);
         if (followLink) {
             await this.agent?.deleteFollow(followLink);
             return true;

--- a/src/agent/HandlerAgent.ts
+++ b/src/agent/HandlerAgent.ts
@@ -195,6 +195,7 @@ export class HandlerAgent {
 
     //region Follow Helpers
 
+    //
     // /**
     //  *
     //  * @param follows

--- a/tests/agent/HandlerAgentFollow.test.ts
+++ b/tests/agent/HandlerAgentFollow.test.ts
@@ -31,6 +31,7 @@ describe('HandlerAgent', () => {
     let getFollowersMock: jest.Mock<any, any, any>;
     const followMock = jest.fn();
     const deleteFollowMock = jest.fn();
+    const getProfileMock = jest.fn();
     beforeEach(() => {
         jest.clearAllMocks();
         getFollowsMock = jest
@@ -45,6 +46,7 @@ describe('HandlerAgent', () => {
             getFollowers: getFollowersMock,
             follow: followMock,
             deleteFollow: deleteFollowMock,
+            getProfile: getProfileMock,
         } as unknown as BskyAgent;
         handlerAgent = new HandlerAgent(
             'agentName',

--- a/tests/agent/HandlerAgentFollow.test.ts
+++ b/tests/agent/HandlerAgentFollow.test.ts
@@ -31,7 +31,7 @@ describe('HandlerAgent', () => {
     let getFollowersMock: jest.Mock<any, any, any>;
     const followMock = jest.fn();
     const deleteFollowMock = jest.fn();
-    const getProfileMock = jest.fn();
+    let getProfileMock: jest.Mock<any, any, any>;
     beforeEach(() => {
         jest.clearAllMocks();
         getFollowsMock = jest
@@ -40,6 +40,7 @@ describe('HandlerAgent', () => {
         getFollowersMock = jest
             .fn()
             .mockReturnValue({ data: { followers: followedByMocks } });
+
         // Require mocked module and define class' methods
         const mockedAgent = {
             getFollows: getFollowsMock,
@@ -68,15 +69,45 @@ describe('HandlerAgent', () => {
         expect(followers).toEqual(followedByMocks);
     });
 
-    it('IsFollowing should call agent getFollows and return true if following', async () => {
+    it('IsFollowing should call agent getProfile and return true if following', async () => {
+        getProfileMock = jest
+            .fn()
+            .mockReturnValue({ data: { viewer: { following: 'uri' } } });
+        const mockedAgent = {
+            getFollows: getFollowsMock,
+            getFollowers: getFollowersMock,
+            follow: followMock,
+            deleteFollow: deleteFollowMock,
+            getProfile: getProfileMock,
+        } as unknown as BskyAgent;
+        handlerAgent = new HandlerAgent(
+            'agentName',
+            testHandle,
+            testPassword,
+            mockedAgent
+        );
         const isFollowing = await handlerAgent.isFollowing('isFollowing');
-        // expect(getFollowsMock).toHaveBeenCalled();
+        expect(getProfileMock).toHaveBeenCalled();
         expect(isFollowing).toBe(true);
     });
 
-    it('IsFollowing should call agent getFollows and return false if not following', async () => {
+    it('IsFollowing should call agent getProfile and return false if not following', async () => {
+        getProfileMock = jest.fn().mockReturnValue({ data: { viewer: {} } });
+        const mockedAgent = {
+            getFollows: getFollowsMock,
+            getFollowers: getFollowersMock,
+            follow: followMock,
+            deleteFollow: deleteFollowMock,
+            getProfile: getProfileMock,
+        } as unknown as BskyAgent;
+        handlerAgent = new HandlerAgent(
+            'agentName',
+            testHandle,
+            testPassword,
+            mockedAgent
+        );
         const isFollowing = await handlerAgent.isFollowing('badDid');
-        // expect(getFollowsMock).toHaveBeenCalled();
+        expect(getProfileMock).toHaveBeenCalled();
         expect(isFollowing).toBe(false);
     });
 
@@ -84,6 +115,7 @@ describe('HandlerAgent', () => {
         getFollowsMock = jest
             .fn()
             .mockReturnValue({ data: { follows: undefined } });
+        getProfileMock = jest.fn().mockReturnValue({ data: undefined });
         const mockedAgent = {
             getFollows: getFollowsMock,
             getFollowers: getFollowersMock,
@@ -98,26 +130,34 @@ describe('HandlerAgent', () => {
             mockedAgent
         );
         const isFollowing = await handlerAgent.isFollowing('badDid');
-        // expect(getFollowsMock).toHaveBeenCalled();
+        expect(getProfileMock).toHaveBeenCalled();
         expect(isFollowing).toBe(false);
     });
 
     it('IsFollowedBy should call agent getFollowers and return true if followed by', async () => {
+        getProfileMock = jest
+            .fn()
+            .mockReturnValue({ data: { viewer: { followedBy: 'uri' } } });
+        const mockedAgent = {
+            getFollows: getFollowsMock,
+            getFollowers: getFollowersMock,
+            follow: followMock,
+            deleteFollow: deleteFollowMock,
+            getProfile: getProfileMock,
+        } as unknown as BskyAgent;
+        handlerAgent = new HandlerAgent(
+            'agentName',
+            testHandle,
+            testPassword,
+            mockedAgent
+        );
         const isFollowedBy = await handlerAgent.isFollowedBy('isFollowedBy');
-        expect(getFollowersMock).toHaveBeenCalled();
+        expect(getProfileMock).toHaveBeenCalled();
         expect(isFollowedBy).toBe(true);
     });
 
     it('IsFollowedBy should call agent getFollowers and return false if not followed by', async () => {
-        const isFollowedBy = await handlerAgent.isFollowedBy('badDid');
-        expect(getFollowersMock).toHaveBeenCalled();
-        expect(isFollowedBy).toBe(false);
-    });
-
-    it('IsFollowedBy should call agent getFollows and return false if undefined response', async () => {
-        getFollowersMock = jest
-            .fn()
-            .mockReturnValue({ data: { followers: undefined } });
+        getProfileMock = jest.fn().mockReturnValue({ data: { viewer: {} } });
         const mockedAgent = {
             getFollows: getFollowsMock,
             getFollowers: getFollowersMock,
@@ -132,7 +172,30 @@ describe('HandlerAgent', () => {
             mockedAgent
         );
         const isFollowedBy = await handlerAgent.isFollowedBy('badDid');
-        expect(getFollowersMock).toHaveBeenCalled();
+        expect(getProfileMock).toHaveBeenCalled();
+        expect(isFollowedBy).toBe(false);
+    });
+
+    it('IsFollowedBy should call agent getFollows and return false if undefined response', async () => {
+        getFollowersMock = jest
+            .fn()
+            .mockReturnValue({ data: { followers: undefined } });
+        getProfileMock = jest.fn().mockReturnValue({ data: undefined });
+        const mockedAgent = {
+            getFollows: getFollowsMock,
+            getFollowers: getFollowersMock,
+            follow: followMock,
+            deleteFollow: deleteFollowMock,
+            getProfile: getProfileMock,
+        } as unknown as BskyAgent;
+        handlerAgent = new HandlerAgent(
+            'agentName',
+            testHandle,
+            testPassword,
+            mockedAgent
+        );
+        const isFollowedBy = await handlerAgent.isFollowedBy('badDid');
+        expect(getProfileMock).toHaveBeenCalled();
         expect(isFollowedBy).toBe(false);
     });
 
@@ -143,18 +206,31 @@ describe('HandlerAgent', () => {
     });
 
     it('deleteFollow should call mock deleteFollow and extract correct url', async () => {
+        getProfileMock = jest
+            .fn()
+            .mockReturnValue({ data: { viewer: { following: 'uri' } } });
+        const mockedAgent = {
+            getFollows: getFollowsMock,
+            getFollowers: getFollowersMock,
+            follow: followMock,
+            deleteFollow: deleteFollowMock,
+            getProfile: getProfileMock,
+        } as unknown as BskyAgent;
+        handlerAgent = new HandlerAgent(
+            'agentName',
+            testHandle,
+            testPassword,
+            mockedAgent
+        );
         const did = 'isFollowing';
         await handlerAgent.unfollowUser(did);
-        expect(deleteFollowMock).toHaveBeenCalledWith('followLink');
+        expect(getProfileMock).toHaveBeenCalledWith({ actor: did });
+        expect(deleteFollowMock).toHaveBeenCalledWith('uri');
     });
 
-    it('deleteFollow should return false when getFollows is undefined', async () => {
+    it('deleteFollow should return false when no profile', async () => {
         const followsRespMock = undefined;
-        getFollowsMock = jest.fn().mockReturnValue({
-            data: {
-                follows: followsRespMock,
-            },
-        });
+        getProfileMock = jest.fn().mockReturnValue({ data: undefined });
         const mockedAgent = {
             getFollows: getFollowsMock,
             getFollowers: getFollowersMock,
@@ -169,30 +245,17 @@ describe('HandlerAgent', () => {
             mockedAgent
         );
 
-        const mockGetRecordForDid = jest.fn().mockReturnValue({});
-        handlerAgent.getRecordForDid = mockGetRecordForDid;
         const did = 'isFollowing';
         const resp = await handlerAgent.unfollowUser(did);
-        expect(mockGetRecordForDid).not.toHaveBeenCalled();
+        expect(getProfileMock).toHaveBeenCalledWith({ actor: did });
+
         expect(deleteFollowMock).not.toHaveBeenCalled();
         expect(resp).toBe(false);
     });
 
-    it('deleteFollow should return false when getFollows is undefined', async () => {
-        const followsRespMock = [
-            {
-                did: 'isFollowing',
-                viewer: {
-                    following: undefined,
-                    followedBy: undefined,
-                },
-            },
-        ];
-        getFollowsMock = jest.fn().mockReturnValue({
-            data: {
-                follows: followsRespMock,
-            },
-        });
+    it('deleteFollow should return false when no profile', async () => {
+        const followsRespMock = undefined;
+        getProfileMock = jest.fn().mockReturnValue({ data: { viewer: {} } });
         const mockedAgent = {
             getFollows: getFollowsMock,
             getFollowers: getFollowersMock,
@@ -207,11 +270,10 @@ describe('HandlerAgent', () => {
             mockedAgent
         );
 
-        const mockGetRecordForDid = jest.fn().mockReturnValue({});
-        handlerAgent.getRecordForDid = mockGetRecordForDid;
         const did = 'isFollowing';
         const resp = await handlerAgent.unfollowUser(did);
-        expect(mockGetRecordForDid).toHaveBeenCalledWith(did, followsRespMock);
+        expect(getProfileMock).toHaveBeenCalledWith({ actor: did });
+
         expect(deleteFollowMock).not.toHaveBeenCalled();
         expect(resp).toBe(false);
     });

--- a/tests/agent/HandlerAgentFollow.test.ts
+++ b/tests/agent/HandlerAgentFollow.test.ts
@@ -89,6 +89,7 @@ describe('HandlerAgent', () => {
             getFollowers: getFollowersMock,
             follow: followMock,
             deleteFollow: deleteFollowMock,
+            getProfile: getProfileMock,
         } as unknown as BskyAgent;
         handlerAgent = new HandlerAgent(
             'agentName',
@@ -122,6 +123,7 @@ describe('HandlerAgent', () => {
             getFollowers: getFollowersMock,
             follow: followMock,
             deleteFollow: deleteFollowMock,
+            getProfile: getProfileMock,
         } as unknown as BskyAgent;
         handlerAgent = new HandlerAgent(
             'agentName',
@@ -158,6 +160,7 @@ describe('HandlerAgent', () => {
             getFollowers: getFollowersMock,
             follow: followMock,
             deleteFollow: deleteFollowMock,
+            getProfile: getProfileMock,
         } as unknown as BskyAgent;
         handlerAgent = new HandlerAgent(
             'agentName',
@@ -195,6 +198,7 @@ describe('HandlerAgent', () => {
             getFollowers: getFollowersMock,
             follow: followMock,
             deleteFollow: deleteFollowMock,
+            getProfile: getProfileMock,
         } as unknown as BskyAgent;
         handlerAgent = new HandlerAgent(
             'agentName',

--- a/tests/agent/HandlerAgentFollow.test.ts
+++ b/tests/agent/HandlerAgentFollow.test.ts
@@ -70,13 +70,13 @@ describe('HandlerAgent', () => {
 
     it('IsFollowing should call agent getFollows and return true if following', async () => {
         const isFollowing = await handlerAgent.isFollowing('isFollowing');
-        expect(getFollowsMock).toHaveBeenCalled();
+        // expect(getFollowsMock).toHaveBeenCalled();
         expect(isFollowing).toBe(true);
     });
 
     it('IsFollowing should call agent getFollows and return false if not following', async () => {
         const isFollowing = await handlerAgent.isFollowing('badDid');
-        expect(getFollowsMock).toHaveBeenCalled();
+        // expect(getFollowsMock).toHaveBeenCalled();
         expect(isFollowing).toBe(false);
     });
 
@@ -98,7 +98,7 @@ describe('HandlerAgent', () => {
             mockedAgent
         );
         const isFollowing = await handlerAgent.isFollowing('badDid');
-        expect(getFollowsMock).toHaveBeenCalled();
+        // expect(getFollowsMock).toHaveBeenCalled();
         expect(isFollowing).toBe(false);
     });
 


### PR DESCRIPTION
So.... The `isFollowing` `isFollowedBy`, `getFollowers`, `getFollowing`, and `unfollowUser` functions didn't actually work at scale. 

The get functions were limited to 50 profiles. isFollowing and followedBy were using those responses to determine a boolean value, so if someone had more than 50 follows or followers, it wouldn't get the full list, and fail.

This fixes it to use `getProfile` and the responses viewer data to determine if the user is following or followed by, and it gets the link to unfollow from this data.