### PR TITLE
Agent- save session data

### DIFF
--- a/src/agent/HandlerAgent.ts
+++ b/src/agent/HandlerAgent.ts
@@ -52,10 +52,6 @@ export class HandlerAgent {
             persistSession: (evt: AtpSessionEvent, sess?: AtpSessionData) => {
                 this.setDid = sess?.did;
                 this.setSession = sess;
-                if (this.session !== undefined) {
-                    DebugLog.warn('AGENT', 'Saving session');
-                    this.saveSessionData(this.session);
-                }
             },
         });
     }
@@ -629,6 +625,10 @@ export class HandlerAgent {
      */
     public set setSession(sess: AtpSessionData | undefined) {
         this.session = sess;
+        if (this.session !== undefined) {
+            DebugLog.warn('AGENT', 'Saving session');
+            this.saveSessionData(this.session);
+        }
     }
 
     /**

--- a/src/agent/README.md
+++ b/src/agent/README.md
@@ -25,6 +25,9 @@ const myBotHandlerAgent = new HandlerAgent(
 ### Methods for Initialization and Authentication
 - `initializeBskyAgent()`: Initializes the `BskyAgent` with the required service URL and session persistence.
 - `authenticate()`: Authenticates the agent using the provided handle and password.
+- `getSessionLocation()`: Returns the filepath of the session.json that is/will be stored when an agent authenticates. Can be modified by setting SESSION_DATA_PATH to the directory you want the session data saved in (i.e. SESSION_DATA_LOCATION='./agentData')
+- `saveSessionData(session: AtpSessionData)`: Saves the agent session data to the file at the path from `getSessionLocation`
+- `loadSessionData(): AtpSessionData|undefined`: Loads the session data stored in the json file at the path from `getSessionLocation`
 
 ### Methods for Follower Interactions
 - `getProfile(did: string)`: Retrieves the profile of the user with the specified DID.

--- a/tests/agent/HandlerAgentGetterSetter.test.ts
+++ b/tests/agent/HandlerAgentGetterSetter.test.ts
@@ -15,7 +15,7 @@ describe('HandlerAgent', () => {
             force: true,
         });
     });
-    fs.mkdirSync('./tests/temp/getterSetter');
+    fs.mkdirSync('./tests/temp/getterSetter', { recursive: true });
 
     let handlerAgent: HandlerAgent;
     const testHandle: string = 'testhandle';

--- a/tests/agent/HandlerAgentGetterSetter.test.ts
+++ b/tests/agent/HandlerAgentGetterSetter.test.ts
@@ -1,12 +1,22 @@
 import { HandlerAgent } from '../../src';
 import { AtpSessionData, BskyAgent } from '@atproto/api';
 import dotenv from 'dotenv';
+import fs from 'fs';
 
 dotenv.config();
+process.env.SESSION_DATA_PATH = './tests/temp/getterSetter';
 
 jest.mock('@atproto/api', () => jest.genMockFromModule('@atproto/api'));
 
 describe('HandlerAgent', () => {
+    afterAll(() => {
+        fs.rmSync('./tests/temp/getterSetter', {
+            recursive: true,
+            force: true,
+        });
+    });
+    fs.mkdirSync('./tests/temp/getterSetter');
+
     let handlerAgent: HandlerAgent;
     const testHandle: string = 'testhandle';
     const testPassword: string = 'testpassword';
@@ -24,6 +34,10 @@ describe('HandlerAgent', () => {
                 testPassword,
                 mockedAgent
             );
+        }
+
+        if (fs.existsSync('./agentName-session.json')) {
+            fs.unlinkSync('./agentName-session.json');
         }
     });
 
@@ -45,6 +59,9 @@ describe('HandlerAgent', () => {
         const testAgentName = 'TestAgent';
         handlerAgent.setAgentName = testAgentName;
         expect(handlerAgent.getAgentName).toBe(testAgentName);
+        if (fs.existsSync('./Test Agent-session.json')) {
+            fs.unlinkSync('./Test Agent-session.json');
+        }
     });
 
     it('#getHandle & setHandle should set correct handle value', () => {
@@ -63,13 +80,20 @@ describe('HandlerAgent', () => {
     });
 
     it('#getSession & setSession should set correct session value', () => {
+        handlerAgent.setAgentName = 'agentName';
+        const saveSessionMock = jest.fn();
+        handlerAgent.saveSessionData = saveSessionMock;
         const testSession = {
             did: 'did:plc:2bnsooklzchcu5ao7xdjosrs',
         } as AtpSessionData;
         handlerAgent.setSession = testSession;
+
+        expect(saveSessionMock).toBeCalledWith(testSession);
+
         expect(handlerAgent.getSession).toBe(testSession);
 
         handlerAgent.setSession = undefined;
         expect(handlerAgent.getSession).toBe(false);
+        expect(saveSessionMock).toBeCalledTimes(1);
     });
 });

--- a/tests/agent/HandlerAgentInitialization.test.ts
+++ b/tests/agent/HandlerAgentInitialization.test.ts
@@ -10,7 +10,12 @@ describe('HandlerAgent', () => {
         process.env.TEST_HANDLE ?? 'testhandle';
     const testPassword: string | undefined =
         process.env.TEST_PASSWORD ?? 'testpassword';
-    const loginMock = jest.fn();
+    const loginMock = jest.fn(() => {
+        handlerAgent.setSession = {
+            did: 'did:plc:2bnsooklzchcu5ao7xdjosrs',
+            // add any other session values needed for your tests
+        } as AtpSessionData;
+    });
     const resumeSessionMock = jest.fn();
     beforeEach(() => {
         if (testHandle !== undefined && testPassword !== undefined) {
@@ -35,18 +40,16 @@ describe('HandlerAgent', () => {
     });
 
     it('authenticate() should login and resume session if agent exists', async () => {
-        // Manually set the session
-        handlerAgent.setSession = {
-            did: 'did:plc:2bnsooklzchcu5ao7xdjosrs',
-            // add any other session values needed for your tests
-        } as AtpSessionData;
-        handlerAgent.setDid = 'did:plc:2bnsooklzchcu5ao7xdjosrs';
+        // Simulate no existing session
+        handlerAgent.setSession = undefined;
+        handlerAgent.setDid = undefined;
+
         await handlerAgent.authenticate();
         expect(loginMock).toHaveBeenCalledTimes(1);
         expect(loginMock).toHaveBeenCalledWith({
             identifier: testHandle,
             password: testPassword,
         });
-        expect(handlerAgent.getDid).toBe('did:plc:2bnsooklzchcu5ao7xdjosrs');
+        expect(handlerAgent.getDid).toBeDefined();
     });
 });

--- a/tests/agent/HandlerAgentInitialization.test.ts
+++ b/tests/agent/HandlerAgentInitialization.test.ts
@@ -1,10 +1,19 @@
 import dotenv from 'dotenv';
 import { HandlerAgent } from '../../src';
 import { AtpSessionData, BskyAgent } from '@atproto/api';
+import fs from 'fs';
 
 dotenv.config();
+process.env.SESSION_DATA_PATH = './tests/temp/initialization';
 
 describe('HandlerAgent', () => {
+    afterAll(() => {
+        fs.rmSync('./tests/temp/initialization', {
+            recursive: true,
+            force: true,
+        });
+    });
+    fs.mkdirSync('./tests/temp/initialization');
     let handlerAgent: HandlerAgent;
     const testHandle: string | undefined =
         process.env.TEST_HANDLE ?? 'testhandle';

--- a/tests/agent/HandlerAgentInitialization.test.ts
+++ b/tests/agent/HandlerAgentInitialization.test.ts
@@ -13,7 +13,7 @@ describe('HandlerAgent', () => {
             force: true,
         });
     });
-    fs.mkdirSync('./tests/temp/initialization');
+    fs.mkdirSync('./tests/temp/initialization', { recursive: true });
     let handlerAgent: HandlerAgent;
     const testHandle: string | undefined =
         process.env.TEST_HANDLE ?? 'testhandle';

--- a/tests/agent/HandlerAgentInitializeAgent.test.ts
+++ b/tests/agent/HandlerAgentInitializeAgent.test.ts
@@ -1,5 +1,10 @@
 import { HandlerAgent } from '../../src';
 import { BskyAgent } from '@atproto/api';
+import fs from 'fs';
+import dotenv from 'dotenv';
+
+dotenv.config();
+process.env.SESSION_DATA_PATH = './tests/temp';
 
 describe('HandlerAgent', () => {
     it('should initialize BskyAgent if agent is not provided', () => {
@@ -24,6 +29,10 @@ describe('HandlerAgent', () => {
 
         // Clean up by removing the spy
         initializeBskyAgentSpy.mockRestore();
+
+        if (fs.existsSync(handlerAgent.getSessionLocation())) {
+            fs.unlinkSync(handlerAgent.getSessionLocation());
+        }
     });
 
     it('should initialize BskyAgent object if agent is null', async () => {
@@ -65,6 +74,10 @@ describe('HandlerAgent', () => {
 
         // Clean up by removing the spy
         initializeBskyAgentSpy.mockRestore();
+
+        if (fs.existsSync(handlerAgent.getSessionLocation())) {
+            fs.unlinkSync(handlerAgent.getSessionLocation());
+        }
     });
 
     it('should throw error when session is undefined', async () => {
@@ -74,6 +87,10 @@ describe('HandlerAgent', () => {
             'Test Handle',
             'Test Password'
         );
+
+        if (fs.existsSync(handlerAgent.getSessionLocation())) {
+            fs.unlinkSync(handlerAgent.getSessionLocation());
+        }
 
         // Set session to null
         handlerAgent.setSession = undefined;
@@ -85,6 +102,10 @@ describe('HandlerAgent', () => {
         await expect(handlerAgent.authenticate()).rejects.toThrow(
             'Could not retrieve bluesky session data for reply bot'
         );
+
+        if (fs.existsSync(handlerAgent.getSessionLocation())) {
+            fs.unlinkSync(handlerAgent.getSessionLocation());
+        }
     });
 
     it('should throw error when agent is undefined after resumeSession', async () => {
@@ -115,5 +136,9 @@ describe('HandlerAgent', () => {
         await expect(handlerAgent.authenticate()).rejects.toThrow(
             `Could not get agent from ${handlerAgent.getAgentName}`
         );
+
+        if (fs.existsSync(handlerAgent.getSessionLocation())) {
+            fs.unlinkSync(handlerAgent.getSessionLocation());
+        }
     });
 });

--- a/tests/agent/HandlerAgentSaveLoadSession.test.ts
+++ b/tests/agent/HandlerAgentSaveLoadSession.test.ts
@@ -8,7 +8,7 @@ dotenv.config();
 process.env.SESSION_DATA_PATH = './tests/temp/saveLoad';
 
 describe('HandlerAgent Session Management', () => {
-    fs.mkdirSync('./tests/temp/saveLoad');
+    fs.mkdirSync('./tests/temp/saveLoad', { recursive: true });
     let handlerAgent: HandlerAgent;
     const testHandle: string | undefined =
         process.env.TEST_HANDLE ?? 'testhandle';

--- a/tests/agent/HandlerAgentSaveLoadSession.test.ts
+++ b/tests/agent/HandlerAgentSaveLoadSession.test.ts
@@ -1,0 +1,119 @@
+import dotenv from 'dotenv';
+import fs from 'fs';
+import path from 'path';
+import { DebugLog, HandlerAgent } from '../../src';
+import { AtpSessionData } from '@atproto/api';
+
+dotenv.config();
+
+describe('HandlerAgent Session Management', () => {
+    let handlerAgent: HandlerAgent;
+    const testHandle: string | undefined =
+        process.env.TEST_HANDLE ?? 'testhandle';
+    const testPassword: string | undefined =
+        process.env.TEST_PASSWORD ?? 'testpassword';
+
+    const sessionData: AtpSessionData = {
+        did: 'did:plc:2bnsooklzchcu5ao7xdjosrs',
+        // Add any other necessary fields for AtpSessionData
+    } as AtpSessionData;
+    const malformedSessionData = '{ malformed JSON }';
+    const sessionFilePath = path.join('.', 'agentName-session.json');
+
+    beforeEach(() => {
+        if (testHandle !== undefined && testPassword !== undefined) {
+            handlerAgent = new HandlerAgent(
+                'agentName',
+                testHandle,
+                testPassword
+            );
+        }
+
+        // Clear any existing session files before each test
+        if (fs.existsSync(sessionFilePath)) {
+            fs.unlinkSync(sessionFilePath);
+        }
+    });
+
+    afterEach(() => {
+        // Clean up any session files after each test
+        if (fs.existsSync(sessionFilePath)) {
+            fs.unlinkSync(sessionFilePath);
+        }
+    });
+
+    it('should load existing session data if the session file exists', async () => {
+        fs.writeFileSync(sessionFilePath, JSON.stringify(sessionData), 'utf8');
+
+        const debugLogSpy = jest.spyOn(DebugLog, 'warn');
+        const resumeMock = jest.fn();
+        // @ts-ignore
+        handlerAgent.agent.resumeSession = resumeMock;
+        await handlerAgent.authenticate();
+
+        expect(debugLogSpy).toHaveBeenCalledWith(
+            'AGENT',
+            'Existing session. Loading session'
+        );
+        expect(handlerAgent['session']).toEqual(sessionData); // Access private properties using bracket notation
+        debugLogSpy.mockRestore();
+        expect(resumeMock).toBeCalledWith(handlerAgent.getSession);
+    });
+
+    it('should log an error and resolve undefined if session data parsing fails', async () => {
+        fs.writeFileSync(sessionFilePath, malformedSessionData, 'utf8');
+
+        const debugLogSpy = jest.spyOn(DebugLog, 'error');
+
+        const loadedSession = await handlerAgent.loadSessionData();
+
+        expect(debugLogSpy).toHaveBeenCalledWith(
+            'AGENT',
+            expect.stringContaining('Failed to parse session data.')
+        );
+        expect(loadedSession).toBeUndefined();
+
+        debugLogSpy.mockRestore();
+    });
+
+    it('should save session data', async () => {
+        await handlerAgent.saveSessionData(sessionData);
+        const savedData = JSON.parse(fs.readFileSync(sessionFilePath, 'utf8'));
+        expect(savedData).toEqual(sessionData);
+    });
+
+    it('should return undefined if the session file does not exist', async () => {
+        const loadedSession = await handlerAgent.loadSessionData();
+        expect(loadedSession).toBeUndefined();
+    });
+
+    it('should load session data when file exists', async () => {
+        fs.writeFileSync(sessionFilePath, JSON.stringify(sessionData), 'utf8');
+        const loadedSession = await handlerAgent.loadSessionData();
+        expect(loadedSession).toEqual(sessionData);
+    });
+
+    it('should handle error when saving session data if writing fails', async () => {
+        jest.spyOn(fs, 'writeFile').mockImplementationOnce(
+            (_, __, callback) => {
+                callback(new Error('Failed to save'));
+            }
+        );
+
+        await expect(handlerAgent.saveSessionData(sessionData)).rejects.toThrow(
+            'Failed to save'
+        );
+    });
+
+    it('should handle error when loading session data if reading fails', async () => {
+        fs.writeFileSync(sessionFilePath, JSON.stringify(sessionData), 'utf8');
+
+        // @ts-ignore
+        jest.spyOn(fs, 'readFile').mockImplementationOnce((_, __, callback) => {
+            callback(new Error('Failed to read'), null as unknown as Buffer);
+        });
+
+        const loadedSession = await handlerAgent.loadSessionData();
+        expect(loadedSession).toBeUndefined();
+    });
+});

--- a/tests/agent/HandlerAgentSaveLoadSession.test.ts
+++ b/tests/agent/HandlerAgentSaveLoadSession.test.ts
@@ -5,8 +5,10 @@ import { DebugLog, HandlerAgent } from '../../src';
 import { AtpSessionData } from '@atproto/api';
 
 dotenv.config();
+process.env.SESSION_DATA_PATH = './tests/temp/saveLoad';
 
 describe('HandlerAgent Session Management', () => {
+    fs.mkdirSync('./tests/temp/saveLoad');
     let handlerAgent: HandlerAgent;
     const testHandle: string | undefined =
         process.env.TEST_HANDLE ?? 'testhandle';
@@ -18,7 +20,7 @@ describe('HandlerAgent Session Management', () => {
         // Add any other necessary fields for AtpSessionData
     } as AtpSessionData;
     const malformedSessionData = '{ malformed JSON }';
-    const sessionFilePath = path.join('.', 'agentName-session.json');
+    const sessionFilePath = './agentName-session.json';
 
     beforeEach(() => {
         if (testHandle !== undefined && testPassword !== undefined) {
@@ -30,25 +32,35 @@ describe('HandlerAgent Session Management', () => {
         }
 
         // Clear any existing session files before each test
-        if (fs.existsSync(sessionFilePath)) {
-            fs.unlinkSync(sessionFilePath);
+        if (fs.existsSync(handlerAgent.getSessionLocation())) {
+            fs.unlinkSync(handlerAgent.getSessionLocation());
         }
     });
 
     afterEach(() => {
         // Clean up any session files after each test
-        if (fs.existsSync(sessionFilePath)) {
-            fs.unlinkSync(sessionFilePath);
+        if (fs.existsSync(handlerAgent.getSessionLocation())) {
+            fs.unlinkSync(handlerAgent.getSessionLocation());
         }
+    });
+    afterAll(() => {
+        fs.rmSync('./tests/temp/saveLoad', { recursive: true, force: true });
     });
 
     it('should load existing session data if the session file exists', async () => {
-        fs.writeFileSync(sessionFilePath, JSON.stringify(sessionData), 'utf8');
+        fs.writeFileSync(
+            handlerAgent.getSessionLocation(),
+            JSON.stringify(sessionData),
+            'utf8'
+        );
 
         const debugLogSpy = jest.spyOn(DebugLog, 'warn');
         const resumeMock = jest.fn();
+        const loginMock = jest.fn();
         // @ts-ignore
         handlerAgent.agent.resumeSession = resumeMock;
+        // @ts-ignore
+        handlerAgent.agent.login = loginMock;
         await handlerAgent.authenticate();
 
         expect(debugLogSpy).toHaveBeenCalledWith(
@@ -61,7 +73,11 @@ describe('HandlerAgent Session Management', () => {
     });
 
     it('should log an error and resolve undefined if session data parsing fails', async () => {
-        fs.writeFileSync(sessionFilePath, malformedSessionData, 'utf8');
+        fs.writeFileSync(
+            handlerAgent.getSessionLocation(),
+            malformedSessionData,
+            'utf8'
+        );
 
         const debugLogSpy = jest.spyOn(DebugLog, 'error');
 
@@ -78,7 +94,9 @@ describe('HandlerAgent Session Management', () => {
 
     it('should save session data', async () => {
         await handlerAgent.saveSessionData(sessionData);
-        const savedData = JSON.parse(fs.readFileSync(sessionFilePath, 'utf8'));
+        const savedData = JSON.parse(
+            fs.readFileSync(handlerAgent.getSessionLocation(), 'utf8')
+        );
         expect(savedData).toEqual(sessionData);
     });
 
@@ -88,7 +106,11 @@ describe('HandlerAgent Session Management', () => {
     });
 
     it('should load session data when file exists', async () => {
-        fs.writeFileSync(sessionFilePath, JSON.stringify(sessionData), 'utf8');
+        fs.writeFileSync(
+            handlerAgent.getSessionLocation(),
+            JSON.stringify(sessionData),
+            'utf8'
+        );
         const loadedSession = await handlerAgent.loadSessionData();
         expect(loadedSession).toEqual(sessionData);
     });
@@ -106,7 +128,11 @@ describe('HandlerAgent Session Management', () => {
     });
 
     it('should handle error when loading session data if reading fails', async () => {
-        fs.writeFileSync(sessionFilePath, JSON.stringify(sessionData), 'utf8');
+        fs.writeFileSync(
+            handlerAgent.getSessionLocation(),
+            JSON.stringify(sessionData),
+            'utf8'
+        );
 
         // @ts-ignore
         jest.spyOn(fs, 'readFile').mockImplementationOnce((_, __, callback) => {

--- a/tests/agent/HandlerAgentUtils.test.ts
+++ b/tests/agent/HandlerAgentUtils.test.ts
@@ -23,7 +23,7 @@ describe('HandlerAgent', () => {
             force: true,
         });
     });
-    fs.mkdirSync('./tests/temp/utils');
+    fs.mkdirSync('./tests/temp/utils', { recursive: true });
     let handlerAgent: HandlerAgent;
     const testHandle: string = 'testhandle';
     const testPassword: string = 'testpassword';

--- a/tests/agent/HandlerAgentUtils.test.ts
+++ b/tests/agent/HandlerAgentUtils.test.ts
@@ -9,12 +9,21 @@ import {
 } from '../../src';
 import { AtpSessionData, BskyAgent } from '@atproto/api';
 import dotenv from 'dotenv';
+import fs from 'fs';
 
 dotenv.config();
+process.env.SESSION_DATA_PATH = './tests/temp/utils';
 
 jest.mock('@atproto/api', () => jest.genMockFromModule('@atproto/api'));
 
 describe('HandlerAgent', () => {
+    afterAll(() => {
+        fs.rmSync('./tests/temp/utils', {
+            recursive: true,
+            force: true,
+        });
+    });
+    fs.mkdirSync('./tests/temp/utils');
     let handlerAgent: HandlerAgent;
     const testHandle: string = 'testhandle';
     const testPassword: string = 'testpassword';

--- a/tests/handlers/premade-handlers/GoodAndBadBotHandler.test.ts
+++ b/tests/handlers/premade-handlers/GoodAndBadBotHandler.test.ts
@@ -11,17 +11,20 @@ import { BskyAgent } from '@atproto/api';
 import dotenv from 'dotenv';
 import fs from 'fs';
 
+const sessPath = './tests/temp/GoodBad';
 dotenv.config();
-process.env.SESSION_DATA_PATH = './tests/temp/GoodBad';
+process.env.SESSION_DATA_PATH = sessPath;
 
 describe('Good and Bad Bot Handler', () => {
     afterAll(() => {
-        fs.rmSync('./tests/temp/GoodBad', {
+        fs.rmSync(sessPath, {
             recursive: true,
             force: true,
         });
     });
-    fs.mkdirSync('./tests/temp/GoodBad');
+    fs.mkdirSync(sessPath);
+    fs.mkdirSync(sessPath, { recursive: true });
+
     let goodBotHandler: GoodBotHandler;
     let badBotHandler: BadBotHandler;
     // let handlerAgent: HandlerAgent;

--- a/tests/handlers/premade-handlers/GoodAndBadBotHandler.test.ts
+++ b/tests/handlers/premade-handlers/GoodAndBadBotHandler.test.ts
@@ -22,7 +22,6 @@ describe('Good and Bad Bot Handler', () => {
             force: true,
         });
     });
-    fs.mkdirSync(sessPath);
     fs.mkdirSync(sessPath, { recursive: true });
 
     let goodBotHandler: GoodBotHandler;

--- a/tests/handlers/premade-handlers/GoodAndBadBotHandler.test.ts
+++ b/tests/handlers/premade-handlers/GoodAndBadBotHandler.test.ts
@@ -8,8 +8,20 @@ import {
     ReplyFactory,
 } from '../../../src';
 import { BskyAgent } from '@atproto/api';
+import dotenv from 'dotenv';
+import fs from 'fs';
+
+dotenv.config();
+process.env.SESSION_DATA_PATH = './tests/temp/GoodBad';
 
 describe('Good and Bad Bot Handler', () => {
+    afterAll(() => {
+        fs.rmSync('./tests/temp/GoodBad', {
+            recursive: true,
+            force: true,
+        });
+    });
+    fs.mkdirSync('./tests/temp/GoodBad');
     let goodBotHandler: GoodBotHandler;
     let badBotHandler: BadBotHandler;
     // let handlerAgent: HandlerAgent;

--- a/tests/handlers/premade-handlers/OfflineHandler.test.ts
+++ b/tests/handlers/premade-handlers/OfflineHandler.test.ts
@@ -20,7 +20,7 @@ describe('Offline Handler', () => {
             force: true,
         });
     });
-    fs.mkdirSync(sessPath);
+    fs.mkdirSync(sessPath, { recursive: true });
     let offlineHandler: OfflineHandler;
     let message: CreateSkeetMessage;
     const mockCreateSkeet = jest.fn();

--- a/tests/handlers/premade-handlers/OfflineHandler.test.ts
+++ b/tests/handlers/premade-handlers/OfflineHandler.test.ts
@@ -6,8 +6,21 @@ import {
     OfflineHandler,
 } from '../../../src';
 import { BskyAgent } from '@atproto/api';
+import fs from 'fs';
+import dotenv from 'dotenv';
 
-describe('Good Bot Handler', () => {
+const sessPath = './tests/temp/handler/offline';
+dotenv.config();
+process.env.SESSION_DATA_PATH = sessPath;
+
+describe('Offline Handler', () => {
+    afterAll(() => {
+        fs.rmSync(sessPath, {
+            recursive: true,
+            force: true,
+        });
+    });
+    fs.mkdirSync(sessPath);
     let offlineHandler: OfflineHandler;
     let message: CreateSkeetMessage;
     const mockCreateSkeet = jest.fn();

--- a/tests/validations/BotValidators/IsBadBotValidator.test.ts
+++ b/tests/validations/BotValidators/IsBadBotValidator.test.ts
@@ -7,6 +7,14 @@ import {
     ReplyFactory,
 } from '../../../src';
 import { BskyAgent } from '@atproto/api';
+import fs from 'fs';
+import dotenv from 'dotenv';
+
+const sessPath = './tests/temp/bot';
+fs.mkdirSync(sessPath, { recursive: true });
+
+dotenv.config();
+process.env.SESSION_DATA_PATH = sessPath;
 
 const botDid = 'did:plc:bot';
 
@@ -22,6 +30,13 @@ const mockAgent: HandlerAgent = new HandlerAgent(
     bskyAgent
 );
 describe('IsBadBotValidator', () => {
+    afterAll(() => {
+        fs.rmSync(sessPath, {
+            recursive: true,
+            force: true,
+        });
+    });
+
     const validator = IsBadBotValidator.make();
 
     it('shouldTrigger returns true for negative bot responses', async () => {

--- a/tests/validations/BotValidators/IsGoodBotValidator.test.ts
+++ b/tests/validations/BotValidators/IsGoodBotValidator.test.ts
@@ -8,6 +8,14 @@ import {
     ReplyFactory,
 } from '../../../src';
 import { BskyAgent } from '@atproto/api';
+import dotenv from 'dotenv';
+import fs from 'fs';
+
+const sessPath = './tests/temp/bot';
+fs.mkdirSync(sessPath, { recursive: true });
+
+dotenv.config();
+process.env.SESSION_DATA_PATH = sessPath;
 
 const botDid = 'did:plc:bot';
 const bskyAgent: BskyAgent = {
@@ -21,7 +29,14 @@ const mockAgent: HandlerAgent = new HandlerAgent(
     'password',
     bskyAgent
 );
+
 describe('IsGoodBotValidator', () => {
+    afterAll(() => {
+        fs.rmSync(sessPath, {
+            recursive: true,
+            force: true,
+        });
+    });
     const validator = IsGoodBotValidator.make();
     const botReply = ReplyFactory.factory().replyTo(botDid).create();
     const skeetRecord = CreateSkeetRecordFactory.factory()

--- a/tests/validations/follow/NewFollowFromUserValidator.test.ts
+++ b/tests/validations/follow/NewFollowFromUserValidator.test.ts
@@ -7,8 +7,21 @@ import {
     UserFollowedValidator,
 } from '../../../src';
 import { BskyAgent } from '@atproto/api';
+import dotenv from 'dotenv';
+import fs from 'fs';
+
+const sessPath = './tests/temp/val/follow/NewFollow';
+dotenv.config();
+process.env.SESSION_DATA_PATH = sessPath;
 
 describe('New Follow From User Validator', () => {
+    afterAll(() => {
+        fs.rmSync(sessPath, {
+            recursive: true,
+            force: true,
+        });
+    });
+    fs.mkdirSync(sessPath, { recursive: true });
     const botDid = 'did:plc:bot';
     const testDid = 'did:plc:test';
     const bskyAgent: BskyAgent = {

--- a/tests/validations/follow/NewFollowerForUserValidator.test.ts
+++ b/tests/validations/follow/NewFollowerForUserValidator.test.ts
@@ -6,8 +6,21 @@ import {
     RecordFactory,
 } from '../../../src';
 import { BskyAgent } from '@atproto/api';
+import dotenv from 'dotenv';
+import fs from 'fs';
+
+const sessPath = './tests/temp/val/follow/NewFollower';
+dotenv.config();
+process.env.SESSION_DATA_PATH = sessPath;
 
 describe('New Follower For User Validator', () => {
+    afterAll(() => {
+        fs.rmSync(sessPath, {
+            recursive: true,
+            force: true,
+        });
+    });
+    fs.mkdirSync(sessPath, { recursive: true });
     const botDid = 'did:plc:bot';
     const bskyAgent: BskyAgent = {
         session: {

--- a/tests/validations/post/PostValidators/IsReplyValidator.test.ts
+++ b/tests/validations/post/PostValidators/IsReplyValidator.test.ts
@@ -5,8 +5,21 @@ import {
     IsReplyValidator,
 } from '../../../../src';
 import { BskyAgent } from '@atproto/api';
+import dotenv from 'dotenv';
+import fs from 'fs';
+
+const sessPath = './tests/temp/val/post/reply';
+dotenv.config();
+process.env.SESSION_DATA_PATH = sessPath;
 
 describe('IsReplyValidator', () => {
+    afterAll(() => {
+        fs.rmSync(sessPath, {
+            recursive: true,
+            force: true,
+        });
+    });
+    fs.mkdirSync(sessPath, { recursive: true });
     const validator = IsReplyValidator.make();
     const botDid = 'did:plc:bot';
     const bskyAgent: BskyAgent = {

--- a/tests/validations/post/PostValidators/PostedByUserValidator.test.ts
+++ b/tests/validations/post/PostValidators/PostedByUserValidator.test.ts
@@ -4,8 +4,21 @@ import {
     HandlerAgent,
     PostedByUserValidator,
 } from '../../../../src';
+import dotenv from 'dotenv';
+import fs from 'fs';
+
+const sessPath = './tests/temp/val/post/postedBy';
+dotenv.config();
+process.env.SESSION_DATA_PATH = sessPath;
 
 describe('Posted by user validator', () => {
+    afterAll(() => {
+        fs.rmSync(sessPath, {
+            recursive: true,
+            force: true,
+        });
+    });
+    fs.mkdirSync(sessPath, { recursive: true });
     const userDid = 'did:plc:user';
     const validator = PostedByUserValidator.make(userDid);
     const handlerAgent: HandlerAgent = {} as HandlerAgent;

--- a/tests/validations/post/PostValidators/ReplyingToBotValidator.test.ts
+++ b/tests/validations/post/PostValidators/ReplyingToBotValidator.test.ts
@@ -6,8 +6,21 @@ import {
     ReplyingToBotValidator,
 } from '../../../../src';
 import { BskyAgent } from '@atproto/api';
+import dotenv from 'dotenv';
+import fs from 'fs';
+
+const sessPath = './tests/temp/val/post/replyToBot';
+dotenv.config();
+process.env.SESSION_DATA_PATH = sessPath;
 
 describe('ReplyingToBotValidator', () => {
+    afterAll(() => {
+        fs.rmSync(sessPath, {
+            recursive: true,
+            force: true,
+        });
+    });
+    fs.mkdirSync(sessPath, { recursive: true });
     const validator = ReplyingToBotValidator.make();
     const botDid = 'did:plc:bot';
 


### PR DESCRIPTION
Added 3 new functions to the Handler agent
`saveSessionData`, `loadSessionData`, and a helper `getSessionLocation`.
Save and Load do what the name implies, they save or load the session json data to a json file on disk, so the bot can resume a session without having to re-login every time.

getSessionLocation will return a filename and path, the session file is {agentName}-session.json, and the path is either `./` or a provided directory with the env variable `SESSION_DATA_PATH`