### PR TITLE
Add new combined GoodAndBadBotHandler

### DIFF
--- a/src/handlers/message-handlers/premade-handlers/BadBotHandler.ts
+++ b/src/handlers/message-handlers/premade-handlers/BadBotHandler.ts
@@ -39,7 +39,6 @@ export class BadBotHandler extends MessageHandler {
         return new BadBotHandler(handlerAgent, response);
     }
 
-    // TODO Update to use JetstreamEventCommit
     async handle(
         handlerAgent: HandlerAgent | undefined,
         message: JetstreamEventCommit

--- a/src/handlers/message-handlers/premade-handlers/GoodAndBadBotHandler.ts
+++ b/src/handlers/message-handlers/premade-handlers/GoodAndBadBotHandler.ts
@@ -1,0 +1,43 @@
+import { HandlerAgent } from '../../../agent/HandlerAgent';
+import { JetstreamEventCommit } from '../../../types/JetstreamTypes';
+import { MessageHandler } from '../MessageHandler';
+import { ReplyingToBotValidator } from '../../../validations/message-validators/post/PostValidators';
+import { BadBotHandler } from './BadBotHandler';
+import { GoodBotHandler } from './GoodBotHandler';
+
+// @ts-ignore
+export class GoodAndBadBotHandler extends MessageHandler {
+    constructor(
+        public handlerAgent: HandlerAgent,
+        public goodResponse: string = 'Thank you 🥹',
+        public badResponse: string = "I'm sorry 😓"
+    ) {
+        super(
+            [ReplyingToBotValidator.make()],
+            [
+                GoodBotHandler.make(handlerAgent, goodResponse),
+                BadBotHandler.make(handlerAgent, badResponse),
+            ],
+            handlerAgent
+        );
+    }
+
+    static make(
+        handlerAgent: HandlerAgent,
+        goodResponse: string | undefined = undefined,
+        badResponse: string | undefined = undefined
+    ): GoodAndBadBotHandler {
+        return new GoodAndBadBotHandler(
+            handlerAgent,
+            goodResponse,
+            badResponse
+        );
+    }
+
+    async handle(
+        handlerAgent: HandlerAgent | undefined,
+        message: JetstreamEventCommit
+    ): Promise<void> {
+        return super.handle(this.handlerAgent, message);
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export { TestMessageHandler } from './handlers/message-handlers/TestMessageHandl
 
 export { GoodBotHandler } from './handlers/message-handlers/premade-handlers/GoodBotHandler';
 export { BadBotHandler } from './handlers/message-handlers/premade-handlers/BadBotHandler';
+export { GoodAndBadBotHandler } from './handlers/message-handlers/premade-handlers/GoodAndBadBotHandler';
 export { OfflineHandler } from './handlers/message-handlers/premade-handlers/OfflineHandler';
 
 /**

--- a/tests/handlers/premade-handlers/GoodAndBadBotHandler.test.ts
+++ b/tests/handlers/premade-handlers/GoodAndBadBotHandler.test.ts
@@ -1,5 +1,6 @@
 import {
     BadBotHandler,
+    GoodAndBadBotHandler,
     GoodBotHandler,
     HandlerAgent,
     JetstreamCommitFactory,
@@ -27,6 +28,7 @@ describe('Good and Bad Bot Handler', () => {
 
     let goodBotHandler: GoodBotHandler;
     let badBotHandler: BadBotHandler;
+    let goodAndBadBotHandler: GoodAndBadBotHandler;
     // let handlerAgent: HandlerAgent;
     let message: JetstreamEventCommit;
     const mockCreateSkeet = jest.fn();
@@ -343,6 +345,171 @@ describe('Good and Bad Bot Handler', () => {
             await badBotHandler.handle(undefined, message);
             expect(mockHasPostReply).toHaveBeenCalledWith(message);
             expect(mockGetDidFromUri).not.toHaveBeenCalled();
+            expect(mockCreateSkeet).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('Good And Bad Bot Handler', () => {
+        it('GoodAndBadBotHandler Does run actions with default when post is reply to bot and bad bot', async () => {
+            goodAndBadBotHandler = GoodAndBadBotHandler.make(handlerAgent);
+            message = JetstreamEventFactory.factory()
+                .fromDid('did:plc:other')
+                .commit(
+                    JetstreamCommitFactory.factory()
+                        .record(
+                            NewSkeetRecordFactory.factory()
+                                .reply(
+                                    ReplyFactory.factory()
+                                        .replyTo(botDid)
+                                        .create()
+                                )
+                                .text('bad bot')
+                                .create()
+                        )
+                        .create()
+                )
+                .create() as JetstreamEventCommit;
+            await goodAndBadBotHandler.handle(undefined, message);
+            expect(mockHasPostReply).toHaveBeenCalledWith(message);
+            expect(mockGetDidFromUri).toHaveBeenCalledWith(
+                message?.commit?.record?.reply?.parent.uri
+            );
+            expect(mockCreateSkeet).toHaveBeenCalledWith(
+                "I'm sorry 😓",
+                handlerAgent.generateReplyFromMessage(message),
+                undefined
+            );
+        });
+
+        it('GoodAndBadBotHandler Does run actions with input when post is reply to bot and bad bot', async () => {
+            goodAndBadBotHandler = GoodAndBadBotHandler.make(
+                handlerAgent,
+                undefined,
+                'test'
+            );
+            message = JetstreamEventFactory.factory()
+                .fromDid('did:plc:other')
+                .commit(
+                    JetstreamCommitFactory.factory()
+                        .record(
+                            NewSkeetRecordFactory.factory()
+                                .reply(
+                                    ReplyFactory.factory()
+                                        .replyTo(botDid)
+                                        .create()
+                                )
+                                .text('bad bot')
+                                .create()
+                        )
+                        .create()
+                )
+                .create() as JetstreamEventCommit;
+
+            await goodAndBadBotHandler.handle(undefined, message);
+            expect(mockHasPostReply).toHaveBeenCalledWith(message);
+            expect(mockGetDidFromUri).toHaveBeenCalledWith(
+                message?.commit?.record?.reply?.parent.uri
+            );
+            expect(mockCreateSkeet).toHaveBeenCalledWith(
+                'test',
+                handlerAgent.generateReplyFromMessage(message),
+                undefined
+            );
+        });
+
+        it('GoodAndBadBotHandler Runs actions when post is reply to bot, and good bot', async () => {
+            goodAndBadBotHandler = GoodAndBadBotHandler.make(handlerAgent);
+            message = JetstreamEventFactory.factory()
+                .fromDid('did:plc:other')
+                .commit(
+                    JetstreamCommitFactory.factory()
+                        .record(
+                            NewSkeetRecordFactory.factory()
+                                .reply(
+                                    ReplyFactory.factory()
+                                        .replyTo(botDid)
+                                        .create()
+                                )
+                                .text('good bot')
+                                .create()
+                        )
+                        .create()
+                )
+                .create() as JetstreamEventCommit;
+
+            await goodAndBadBotHandler.handle(undefined, message);
+            expect(mockHasPostReply).toHaveBeenCalledWith(message);
+            expect(mockGetDidFromUri).toHaveBeenCalledWith(
+                message?.commit?.record?.reply?.parent.uri
+            );
+            expect(mockCreateSkeet).toHaveBeenCalledWith(
+                'Thank you 🥹',
+                handlerAgent.generateReplyFromMessage(message),
+                undefined
+            );
+        });
+
+        it('GoodAndBadBotHandler Runs actions when post is reply to bot, and good bot', async () => {
+            goodAndBadBotHandler = GoodAndBadBotHandler.make(
+                handlerAgent,
+                'test',
+                undefined
+            );
+            message = JetstreamEventFactory.factory()
+                .fromDid('did:plc:other')
+                .commit(
+                    JetstreamCommitFactory.factory()
+                        .record(
+                            NewSkeetRecordFactory.factory()
+                                .reply(
+                                    ReplyFactory.factory()
+                                        .replyTo(botDid)
+                                        .create()
+                                )
+                                .text('good bot')
+                                .create()
+                        )
+                        .create()
+                )
+                .create() as JetstreamEventCommit;
+
+            await goodAndBadBotHandler.handle(undefined, message);
+            expect(mockHasPostReply).toHaveBeenCalledWith(message);
+            expect(mockGetDidFromUri).toHaveBeenCalledWith(
+                message?.commit?.record?.reply?.parent.uri
+            );
+            expect(mockCreateSkeet).toHaveBeenCalledWith(
+                'test',
+                handlerAgent.generateReplyFromMessage(message),
+                undefined
+            );
+        });
+
+        it('GoodAndBadBotHandler Does not run actions when post is not reply to bot', async () => {
+            goodAndBadBotHandler = GoodAndBadBotHandler.make(handlerAgent);
+            message = JetstreamEventFactory.factory()
+                .fromDid('did:plc:other')
+                .commit(
+                    JetstreamCommitFactory.factory()
+                        .record(
+                            NewSkeetRecordFactory.factory()
+                                .reply(
+                                    ReplyFactory.factory()
+                                        .replyTo('did:plc:other')
+                                        .create()
+                                )
+                                .text('bad bot')
+                                .create()
+                        )
+                        .create()
+                )
+                .create() as JetstreamEventCommit;
+
+            await goodAndBadBotHandler.handle(undefined, message);
+            expect(mockGetDidFromUri).toHaveBeenCalledWith(
+                message?.commit?.record?.reply?.parent.uri
+            );
+            expect(mockHasPostReply).not.toHaveBeenCalled();
             expect(mockCreateSkeet).not.toHaveBeenCalled();
         });
     });


### PR DESCRIPTION
For many bots, i had to add
```typescript
GoodBotHandler.make(handlerAgent),
BadBotHandler.make(handlerAgent)
```

but this PR adds in a new `GoodAndBadBotHandler` to be able to add both in a single line.